### PR TITLE
Cleanup temp docker config dir

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,4 +3,4 @@ services:
   tests:
     image: buildkite/plugin-tester
     volumes:
-      - ".:/plugin:ro"
+      - ".:/plugin"

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Deleting temp DOCKER_CONFIG dir \"${DOCKER_CONFIG}\""
+
+rm -r "$DOCKER_CONFIG"

--- a/tests/pre-exit.bats
+++ b/tests/pre-exit.bats
@@ -1,0 +1,14 @@
+#!/usr/bin/env bats
+
+load '/usr/local/lib/bats/load.bash'
+
+@test "Cleans up the docker login cache" {
+  mkdir -p 'tests/tmp/.docker-login'
+
+  export DOCKER_CONFIG='tests/tmp/.docker-login'
+
+  run "$PWD/hooks/pre-exit"
+
+  assert_success
+  assert [ ! -e 'tests/tmp/.docker-login' ]
+}


### PR DESCRIPTION
This plugin creates a temporary directory to store the docker config.

This PR ensures the temporary directory is deleted once the build step has finished.

The tests can be run using `docker-compose run tests`.